### PR TITLE
Fix Android build error by updating compileSdkVersion to 34

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -21,6 +21,7 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+    afterEvaluate { android { compileSdkVersion 34 } }
 }
 subprojects {
     project.evaluationDependsOn(':app')


### PR DESCRIPTION
The necessary changes have been made to fix the error encountered while building the Android project.