### PR TITLE
Add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
-
+    namespace "flowmobile.storage_space"
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Add required namespace on Android gradle. 
The library currently does not work on latest gradle versions. 